### PR TITLE
Fix #7: Rename package to avoid conflicts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# Plug.Stats
+# PlugStats
 
 This Plug is meant to help collect statistics about the time it takes your application to process
 HTTP requests. It emits a value for the processing time after every processed HTTP request.
 
 The backend needs to provide a `histogram` function that the Plug uses to send the metrics over. This
-function's behavior is described in `Plug.Stats.Behaviours.Backend`.
+function's behavior is described in `PlugStats.Behaviours.Backend`.
 
 The metric emitted is called "web.request" (configurable) and
 contains the following tags:

--- a/lib/plug/backend_behaviour.ex
+++ b/lib/plug/backend_behaviour.ex
@@ -1,3 +1,3 @@
-defmodule Plug.Stats.Behaviours.Backend do
+defmodule PlugStats.Behaviours.Backend do
   @callback histogram(String.t(), Integer.t(), list(Keyword.t())) :: none()
 end

--- a/lib/plug/stats.ex
+++ b/lib/plug/stats.ex
@@ -1,4 +1,4 @@
-defmodule Plug.Stats do
+defmodule PlugStats do
   @moduledoc """
   This Plug emits metrics after every processed HTTP request.
 

--- a/mix.exs
+++ b/mix.exs
@@ -1,4 +1,4 @@
-defmodule Plug.Stats.MixProject do
+defmodule PlugStats.MixProject do
   use Mix.Project
 
   def project do

--- a/test/plugs/stats_test.exs
+++ b/test/plugs/stats_test.exs
@@ -1,11 +1,11 @@
-defmodule Plug.StatsTest do
+defmodule PlugStatsTest do
   use ExUnit.Case
 
   import Plug.Conn
   import Phoenix.ConnTest
   import Mox
 
-  alias Plug.Stats.MetricsMock
+  alias PlugStats.MetricsMock
 
   setup :verify_on_exit!
 
@@ -20,8 +20,8 @@ defmodule Plug.StatsTest do
     conn =
       build_conn(:post, "/resource")
       |> put_private(:phoenix_action, :create)
-      |> put_private(:phoenix_controller, Plug.Stats.DummyController)
-      |> Plug.Stats.call(backend: MetricsMock, metric_name: "web.request")
+      |> put_private(:phoenix_controller, PlugStats.DummyController)
+      |> PlugStats.call(backend: MetricsMock, metric_name: "web.request")
 
     # Simulate request processing.
     Process.sleep(1)
@@ -32,7 +32,7 @@ defmodule Plug.StatsTest do
   test "doesn't emit anything if request didn't reach Phoenix" do
     conn =
       build_conn()
-      |> Plug.Stats.call(backend: MetricsMock, metric_name: "web.request")
+      |> PlugStats.call(backend: MetricsMock, metric_name: "web.request")
 
     send_resp(conn, 200, "Response OK")
   end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,3 +1,3 @@
 ExUnit.start()
 
-Mox.defmock(Plug.Stats.MetricsMock, for: Plug.Stats.Behaviours.Backend)
+Mox.defmock(PlugStats.MetricsMock, for: PlugStats.Behaviours.Backend)


### PR DESCRIPTION
The Plug. namespace belongs to the Plug project, and using it as a
prefix in namespaces [is discouraged](https://hex.pm/docs/publish):

> Plug owns the Plug namespace, if you have an authentication package for Plug use the namespace PlugAuth instead of Plug.Auth.