### PR TITLE
Assign codeowners to tm-quantum

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @salemove/tm-quantum


### PR DESCRIPTION
This PR adds CODEOWNERS file and assigns tm-quantum as codeowners.